### PR TITLE
fix(security): convert backfillSentenceDifficulty to internalMutation

### DIFF
--- a/convex/reviews.ts
+++ b/convex/reviews.ts
@@ -1,4 +1,4 @@
-import { mutation, query } from "./_generated/server";
+import { internalMutation, mutation, query } from "./_generated/server";
 import { v, ConvexError } from "convex/values";
 
 const DEFAULT_LIMIT = 10;
@@ -228,7 +228,8 @@ export const getMasteredAtLevel = query({
 });
 
 // One-time migration: backfill sentenceDifficulty for existing reviews
-export const backfillSentenceDifficulty = mutation({
+// Internal mutation: only callable from Convex dashboard/scripts, not from client
+export const backfillSentenceDifficulty = internalMutation({
   handler: async (ctx) => {
     const reviews = await ctx.db.query("sentenceReviews").collect();
     let updated = 0;


### PR DESCRIPTION
## Summary

- Converts `backfillSentenceDifficulty` mutation to `internalMutation` to prevent unauthorized access
- Previously, anyone with the Convex deployment URL could modify all users' review records

## Security Impact

**Severity: HIGH** → **Resolved**

The migration mutation was publicly callable, allowing mass data modification. Now only callable from Convex dashboard/scripts.

## Test plan

- [x] TypeScript compiles
- [x] All tests pass
- [x] Convex functions build successfully
- [x] Verify mutation is no longer exposed in client-side API

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restricted the scope of an internal operation to limit its callable context.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->