### PR TITLE
ci: run next typegen before tsc --noEmit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Lint
         run: pnpm lint
 
+      - name: Generate Next.js types
+        run: npx next typegen
+
       - name: Type check
         run: pnpm tsc --noEmit
 


### PR DESCRIPTION
## Summary
- Add `npx next typegen` step before type checking in CI
- Ensures Next.js 16.1+ route types exist before `tsc --noEmit` runs
- Makes CI more robust (currently works because build runs later, but this is fragile)

## Test plan
- [ ] CI passes with the new step
- [ ] Type checking correctly finds route types

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI pipeline with improved type generation workflow to strengthen build reliability and code quality checks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->