### PR TITLE
fix: Show helpful error when Convex auth is misconfigured

### DIFF
--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -1,5 +1,4 @@
-import { auth } from '@n    extjs/server';
-import { redirect } from 'next/navigation';
+import { auth } from '@clerk/nextjs/server';
 
 import { createDataAdapter } from '@/lib/data/adapter';
 import type { ContentSeed, ProgressMetrics, Session, UserProgress as DataUserProgress } from '@/lib/data/types';
@@ -48,12 +47,12 @@ function AuthConfigError(): React.JSX.Element {
           </ol>
         </div>
 
-        <button
-          onClick={() => window.location.reload()}
-          className="w-full bg-accent text-white px-6 py-3 rounded-button font-medium hover:opacity-90 transition-opacity"
+        <a
+          href="/dashboard"
+          className="w-full block bg-accent text-white px-6 py-3 rounded-button font-medium hover:opacity-90 transition-opacity text-center"
         >
           Try Again
-        </button>
+        </a>
       </div>
     </main>
   );


### PR DESCRIPTION
## Problem
Dashboard crashes with generic "Something went wrong" error when Clerk JWT template for Convex is not configured.

## Solution
Instead of throwing and hitting the error boundary, now shows a specific auth configuration error with clear troubleshooting steps for administrators.

## Changes
- Adds `AuthConfigError` component with helpful troubleshooting steps
- Detects missing Convex token in production and renders specific error UI
- Logs detailed error message for debugging

## Fixes
Closes #65

## Testing
- [ ] Test with missing JWT template (should show new error UI)
- [ ] Test with valid config (should work normally)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Dashboard now shows a clear authentication error UI and logs a message when the required token is missing; in production this short-circuits dashboard data loading to prevent runtime failures and surface configuration issues more visibly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->