### PR TITLE
fix: enforce route-level grading input length caps

### DIFF
--- a/app/api/grade/__tests__/route.test.ts
+++ b/app/api/grade/__tests__/route.test.ts
@@ -43,6 +43,24 @@ describe('POST /api/grade', () => {
     expect(submitReviewForUser).not.toHaveBeenCalled();
   });
 
+  it('returns 400 for oversized input before rate limiting', async () => {
+    const req = new Request('http://localhost/api/grade', {
+      method: 'POST',
+      body: JSON.stringify({
+        sessionId: 'sess-1',
+        itemIndex: 0,
+        userInput: 'a'.repeat(1001),
+      }),
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBe('Input too long');
+    expect(consumeAiCall).not.toHaveBeenCalled();
+    expect(submitReviewForUser).not.toHaveBeenCalled();
+  });
+
   it('invokes submitReviewForUser and returns result with rate limit info', async () => {
     submitReviewForUser.mockResolvedValueOnce({
       result: { status: 'CORRECT', feedback: 'Nice.', correction: undefined },

--- a/app/api/grade/route.ts
+++ b/app/api/grade/route.ts
@@ -4,6 +4,7 @@ import { submitReviewForUser } from '@/app/(app)/session/[sessionId]/actions';
 import { consumeAiCall } from '@/lib/rateLimit/inMemoryRateLimit';
 
 export const runtime = 'nodejs';
+const MAX_USER_INPUT_LENGTH = 1000;
 
 export async function POST(req: Request) {
   const { userId, getToken } = await auth();
@@ -22,6 +23,10 @@ export async function POST(req: Request) {
 
     if (typeof sessionId !== 'string' || typeof itemIndex !== 'number' || typeof userInput !== 'string') {
       return NextResponse.json({ error: 'Invalid payload' }, { status: 400 });
+    }
+
+    if (userInput.length > MAX_USER_INPUT_LENGTH) {
+      return NextResponse.json({ error: 'Input too long' }, { status: 400 });
     }
 
     // Check rate limit before calling AI

--- a/app/api/phrase-review/__tests__/route.test.ts
+++ b/app/api/phrase-review/__tests__/route.test.ts
@@ -89,6 +89,24 @@ describe('POST /api/phrase-review', () => {
     expect(consumeAiCall).not.toHaveBeenCalled();
   });
 
+  it('returns 400 for oversized input before rate limiting', async () => {
+    const req = new Request('http://localhost/api/phrase-review', {
+      method: 'POST',
+      body: JSON.stringify({
+        sessionId: 'sess-1',
+        itemIndex: 0,
+        phraseCardId: 'card-1',
+        userInput: 'a'.repeat(501),
+      }),
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBe('Input too long');
+    expect(consumeAiCall).not.toHaveBeenCalled();
+  });
+
   it('returns 429 when rate limit exceeded', async () => {
     const resetAtMs = Date.now() + 3600000;
     consumeAiCall.mockReturnValueOnce({ allowed: false, remaining: 0, resetAtMs });

--- a/app/api/phrase-review/route.ts
+++ b/app/api/phrase-review/route.ts
@@ -12,6 +12,8 @@ import { consumeAiCall } from '@/lib/rateLimit/inMemoryRateLimit';
 
 export const runtime = 'nodejs';
 
+const MAX_USER_INPUT_LENGTH = 500;
+
 // State enum ↔ string helpers
 type StateString = 'new' | 'learning' | 'review' | 'relearning';
 
@@ -86,6 +88,10 @@ export async function POST(req: Request) {
       typeof userInput !== 'string'
     ) {
       return NextResponse.json({ error: 'Invalid payload' }, { status: 400 });
+    }
+
+    if (userInput.length > MAX_USER_INPUT_LENGTH) {
+      return NextResponse.json({ error: 'Input too long' }, { status: 400 });
     }
 
     // Check rate limit before calling AI

--- a/app/api/vocab-review/__tests__/route.test.ts
+++ b/app/api/vocab-review/__tests__/route.test.ts
@@ -89,6 +89,24 @@ describe('POST /api/vocab-review', () => {
     expect(consumeAiCall).not.toHaveBeenCalled();
   });
 
+  it('returns 400 for oversized input before rate limiting', async () => {
+    const req = new Request('http://localhost/api/vocab-review', {
+      method: 'POST',
+      body: JSON.stringify({
+        sessionId: 'sess-1',
+        itemIndex: 0,
+        vocabCardId: 'card-1',
+        userInput: 'a'.repeat(501),
+      }),
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBe('Input too long');
+    expect(consumeAiCall).not.toHaveBeenCalled();
+  });
+
   it('returns 429 when rate limit exceeded', async () => {
     const resetAtMs = Date.now() + 3600000;
     consumeAiCall.mockReturnValueOnce({ allowed: false, remaining: 0, resetAtMs });

--- a/app/api/vocab-review/route.ts
+++ b/app/api/vocab-review/route.ts
@@ -12,6 +12,8 @@ import { consumeAiCall } from '@/lib/rateLimit/inMemoryRateLimit';
 
 export const runtime = 'nodejs';
 
+const MAX_USER_INPUT_LENGTH = 500;
+
 // State enum ↔ string helpers
 type StateString = 'new' | 'learning' | 'review' | 'relearning';
 
@@ -86,6 +88,10 @@ export async function POST(req: Request) {
       typeof userInput !== 'string'
     ) {
       return NextResponse.json({ error: 'Invalid payload' }, { status: 400 });
+    }
+
+    if (userInput.length > MAX_USER_INPUT_LENGTH) {
+      return NextResponse.json({ error: 'Input too long' }, { status: 400 });
     }
 
     // Check rate limit before calling AI


### PR DESCRIPTION
Closes #77

This adds route boundary guards for grading input lengths before rate limiting/AI calls.

- /api/vocab-review: reject userInput > 500
- /api/phrase-review: reject userInput > 500
- /api/grade: reject userInput > 1000

Validation:
- bun vitest app/api/grade/__tests__/route.test.ts app/api/phrase-review/__tests__/route.test.ts app/api/vocab-review/__tests__/route.test.ts
- lefthook hooks ran on commit (pre-commit)
- pre-push run completed: build, env-parity, full test pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Implemented input length validation on the grading, phrase review, and vocabulary review endpoints to prevent processing of requests with excessively long input.

* **Tests**
  * Added test coverage to verify input length validation works correctly across affected endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->