### PR TITLE
feat: OG metadata, reading glossary, and mastery progress widget

### DIFF
--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -16,6 +16,7 @@ import { JourneyProgress } from '@/components/dashboard/JourneyProgress';
 import { XPDisplay } from '@/components/dashboard/XPDisplay';
 import { TrialBanner } from '@/components/dashboard/TrialBanner';
 import { TimezoneSync } from '@/components/dashboard/TimezoneSync';
+import { MasteryProgress } from '@/components/dashboard/MasteryProgress';
 
 export const dynamic = 'force-dynamic';
 
@@ -210,6 +211,8 @@ export default async function DashboardPage(): Promise<React.JSX.Element> {
           <LegionStatus legion={metrics.legion} />
           <XPDisplay xp={metrics.xp} />
         </div>
+
+        <MasteryProgress masteredCount={metrics.legion.decuriones} readingLevel={progress.unlockedPhase} />
 
         <JourneyProgress iter={metrics.iter} />
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -34,12 +34,17 @@ const inter = Inter({
 
 export const metadata: Metadata = {
   title: 'Caesar in a Year',
-  description: 'Learn to read De Bello Gallico with daily guided sessions.',
+  description: 'Daily guided Latin sessions to read De Bello Gallico in one year',
   openGraph: {
+    title: 'Caesar in a Year',
+    description: 'Daily guided Latin sessions to read De Bello Gallico in one year',
+    url: 'https://caesarinayear.com',
+    type: 'website',
     images: ['/og.png'],
   },
   twitter: {
     card: 'summary_large_image',
+    title: 'Caesar in a Year',
   },
 };
 

--- a/lib/data/convexAdapter.ts
+++ b/lib/data/convexAdapter.ts
@@ -3,6 +3,11 @@ import { api } from '@/convex/_generated/api';
 import { DAILY_READING, REVIEW_SENTENCES } from '@/constants';
 import { provisionCardsForSentences } from './provisionCards';
 import {
+  loadEnrichedCorpus,
+  getVocabForSentences,
+  isEnrichedCorpusLoaded,
+} from './enrichedCorpus';
+import {
   Attempt,
   AttemptHistoryEntry,
   ContentSeed,
@@ -104,15 +109,26 @@ function mapSentence(doc: SentenceDoc): Sentence {
   };
 }
 
+function buildGlossaryFromCorpus(sentenceIds: string[]): Record<string, string> {
+  if (!isEnrichedCorpusLoaded()) return {};
+  const vocab = getVocabForSentences(sentenceIds);
+  const glossary: Record<string, string> = {};
+  for (const v of vocab) {
+    glossary[v.latinWord] = v.meaning;
+  }
+  return glossary;
+}
+
 function mapToReading(sentences: SentenceDoc[]): ReadingPassage {
   const first = sentences[0];
   const parts = first.sentenceId.split('.');
+  const sentenceIds = sentences.map((s) => s.sentenceId);
   return {
     id: `reading-${first.sentenceId}`,
     title: `De Bello Gallico ${parts.slice(1, 3).join('.')}`,
     latinText: sentences.map((s) => s.latin),
-    sentenceIds: sentences.map((s) => s.sentenceId),
-    glossary: {},
+    sentenceIds,
+    glossary: buildGlossaryFromCorpus(sentenceIds),
     gistQuestion: 'Translate this passage into natural English.',
     referenceGist: sentences.map((s) => s.referenceTranslation).join(' '),
   };
@@ -178,6 +194,9 @@ export class ConvexAdapter implements DataAdapter {
   }
 
   async getContent(userId: string, daysActive?: number): Promise<ContentSeed> {
+    // Ensure enriched corpus is loaded for glossary population
+    await loadEnrichedCorpus();
+
     // Import config to determine fetch limits based on user progress
     const { getSessionConfig } = await import('@/lib/session/config');
     const config = getSessionConfig(daysActive ?? 1);


### PR DESCRIPTION
Closes #88 #83 #82

- Complete OpenGraph/Twitter card metadata in app/layout.tsx (#88)
- Populate reading glossary from enriched corpus vocab in mapToReading() (#83)
- Wire MasteryProgress component into dashboard page (#82)

Generated by Agent 2 in flywheel-experiment sprite run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Mastery Progress component to the dashboard displaying mastery achievements and reading level progression alongside existing progress indicators.
  * Enhanced the glossary with enriched vocabulary data to provide comprehensive word definitions and improved learning context.

* **Documentation**
  * Updated metadata to enhance content sharing across platforms and improve search engine discoverability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->