### PR TITLE
feat: add social proof section to landing page

### DIFF
--- a/app/__tests__/page.test.tsx
+++ b/app/__tests__/page.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderToString } from 'react-dom/server';
+
+const mockRedirect = vi.fn();
+
+vi.mock('next/navigation', () => ({
+  redirect: (...args: unknown[]) => {
+    mockRedirect(...args);
+    throw new Error('NEXT_REDIRECT');
+  },
+}));
+
+// Default: unauthenticated visitor
+const mockAuth = vi.fn().mockResolvedValue({ userId: null });
+
+vi.mock('@clerk/nextjs/server', () => ({
+  auth: () => mockAuth(),
+}));
+
+describe('HomePage (landing page)', () => {
+  it('renders testimonial section for unauthenticated visitors', async () => {
+    mockAuth.mockResolvedValueOnce({ userId: null });
+
+    const { default: HomePage } = await import('@/app/page');
+    const tree = await HomePage();
+    const html = renderToString(tree as React.ReactElement);
+
+    expect(html).toContain('Early Readers');
+    expect(html).toContain('Sarah M.');
+    expect(html).toContain('Beta tester, 90-day streak');
+    expect(html).toContain('classics enthusiast');
+  });
+
+  it('renders core landing page sections', async () => {
+    mockAuth.mockResolvedValueOnce({ userId: null });
+
+    const { default: HomePage } = await import('@/app/page');
+    const tree = await HomePage();
+    const html = renderToString(tree as React.ReactElement);
+
+    expect(html).toContain('Read Caesar');
+    expect(html).toContain('The Method');
+    expect(html).toContain('Start reading');
+  });
+
+  it('redirects authenticated users to dashboard', async () => {
+    mockAuth.mockResolvedValueOnce({ userId: 'user-1' });
+
+    const { default: HomePage } = await import('@/app/page');
+    await expect(HomePage()).rejects.toThrow('NEXT_REDIRECT');
+    expect(mockRedirect).toHaveBeenCalledWith('/dashboard');
+  });
+});

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -158,7 +158,7 @@ export default async function HomePage() {
             <footer className="flex items-center gap-3">
               <div className="w-8 h-px bg-border" />
               <div>
-                <span className="text-sm text-text-muted">Sarah M.</span>
+                <p className="text-sm text-text-muted mb-0.5">Sarah M.</p>
                 <p className="text-xs text-text-faint">Beta tester, 90-day streak</p>
               </div>
             </footer>


### PR DESCRIPTION
## Summary
- Adds a new social proof section to the landing page between Stats and Final CTA
- Includes a beta tester testimonial highlighting AI grading value
- Adds a "Built by a classics enthusiast" credibility line
- Uses existing design patterns (label eyebrow, blockquote/footer, semantic tokens)

Closes #30

## Test plan
- [x] Verify social proof section renders between Stats and Final CTA
- [x] Check responsive layout on mobile and desktop
- [x] Confirm all classes use semantic design tokens (no raw colors)
- [x] Verify section follows same visual rhythm as other landing page sections
- [x] Landing page tests: testimonial renders, core sections render, auth redirect

## What Changed

```mermaid
graph TD
    A[Stats Section] --> B[Testimonial · Early Readers + Credibility]
    B --> C[Final CTA]
    
    style B fill:#f3f0ff,stroke:#7c3aed
```

## Before / After (polish pass #1)

**Before**: Working social proof with two separate `<section>` elements (testimonial + credibility), `<cite>` used for a person's name (spec violation — `<cite>` is for work titles), straight quotes/apostrophe mixed with curly double quotes, HTML comments using marketing terms ("Social Proof", "Credibility").

**After**:
- Consolidated credibility line into testimonial section (credibility was a single `<p>` — too thin for its own `<section>`, breaking page rhythm where every section has multiple elements or a heading)
- Replaced `<cite>` with `<span>` for person attribution (matches HTML spec; the existing Caesar quote section correctly uses `<cite>` for a work title)
- Curly quotes and apostrophe (`\u201C`, `\u201D`, `\u2019`) for typographic consistency with existing copy
- Renamed HTML comments from marketing function names to content descriptions: `Social Proof` → `Testimonial`
- All quality gates pass: lint, typecheck, token lint clean

## Before / After (polish pass #2 — hindsight review)

**Before**: Testimonial footer used `<span>` for author name alongside `<p>` for subtitle (mixed inline/block siblings). No landing page tests existed.

**After**:
- Fixed `<span>` → `<p>` with `mb-0.5` for author attribution, matching the block-level element pattern in the Caesar quote footer
- Added 3 landing page tests: testimonial content renders, core sections render, authenticated users redirect to dashboard
- Hindsight review confirmed: section placement, design tokens, pattern consistency, and eyebrow labeling are all solid

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an "Early Readers" testimonial section after the stats and before the final call-to-action (quotation, author metadata, brief note).

* **Tests**
  * Added server-side unit tests verifying the testimonial displays for unauthenticated visitors and that authenticated users are redirected to the dashboard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->