### PR TITLE
feat: wire MasteryProgress to dashboard

### DIFF
--- a/app/(app)/dashboard/__tests__/page.test.tsx
+++ b/app/(app)/dashboard/__tests__/page.test.tsx
@@ -100,6 +100,46 @@ describe('DashboardPage', () => {
     expect(getProgressMetrics).toHaveBeenCalledWith('user-1', 0);
   });
 
+  it('renders MasteryProgress with data from getMasteredAtLevel', async () => {
+    getUserProgress.mockResolvedValueOnce({
+      userId: 'user-1',
+      streak: 3,
+      totalXp: 150,
+      maxDifficulty: 2,
+      lastSessionAt: Date.now() - 86400000,
+    });
+    getContent.mockResolvedValueOnce({
+      review: [{ id: 's1', latin: 'Gallia est omnis divisa', english: 'All Gaul is divided', reference: 'BG 1.1', difficulty: 1, sentenceIndex: 0, passageId: 'p1' }],
+      reading: {
+        id: 'r1',
+        title: 'Sample Reading',
+        latinText: [],
+        glossary: {},
+        gistQuestion: '',
+        referenceGist: '',
+      },
+    });
+    getProgressMetrics.mockResolvedValueOnce({
+      legion: { tirones: 0, milites: 0, veterani: 0, decuriones: 0 },
+      iter: { sentencesEncountered: 5, totalSentences: 365, percentComplete: 1, contentDay: 5, daysActive: 5, scheduleDelta: 0 },
+      activity: [],
+      xp: { total: 150, level: 2, currentLevelXp: 50, toNextLevel: 100 },
+      streak: 3,
+    });
+    getMasteredAtLevel.mockResolvedValueOnce(12);
+
+    const { default: DashboardPage } = await import('@/app/(app)/dashboard/page');
+    const tree = await DashboardPage();
+    const html = renderToString(tree as React.ReactElement);
+
+    // MasteryProgress renders reading level and mastery count
+    // React SSR inserts <!-- --> between expressions, so match the label text instead
+    expect(html).toContain('Gradus Lectionis');
+    expect(html).toContain('Perfectae: 12/20');
+    expect(html).toContain('Mastered: 12/20');
+    expect(getMasteredAtLevel).toHaveBeenCalledWith('user-1', 2);
+  });
+
   it('does not render FirstSessionGuidance for returning users', async () => {
     getUserProgress.mockResolvedValueOnce({
       userId: 'user-1',

--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -92,6 +92,7 @@ async function getDashboardData(userId: string, token: string | undefined, tzOff
     data.getActiveSession(),
   ]);
 
+  // Sequential: depends on rawProgress.maxDifficulty from the parallel batch above
   const maxDifficulty = rawProgress?.maxDifficulty ?? 1;
   const masteredCount = await data.getMasteredAtLevel(userId, maxDifficulty);
 


### PR DESCRIPTION
## Summary
- Import and render the existing `MasteryProgress` component on the dashboard page
- Fetch `masteredCount` via `getMasteredAtLevel()` and pass it alongside `readingLevel` (from `maxDifficulty`) as props
- Update dashboard test mock to include the new `getMasteredAtLevel` adapter method

Closes #82

## Test plan
- [x] TypeScript typecheck passes (`npx tsc --noEmit`)
- [x] Dashboard unit tests pass (`bun test --run app/(app)/dashboard/__tests__/page.test.tsx`)
- [x] ESLint + token lint clean (`bun check`)
- [ ] Visual verification: `bun dev` → navigate to `/dashboard` → MasteryProgress shows reading level and mastery count

## Before / After

**Before:** PR was conflicting with master due to concurrent additions (`FirstSessionGuidance`/`isNewUser` on master, `MasteryProgress` mastery data on this branch). Additionally, a duplicate `MasteryProgress` import and render existed from the auto-merge.

**After:** Rebased onto master. Merged both features cleanly — dashboard now has both `FirstSessionGuidance` for new users and `MasteryProgress` with properly-fetched mastery data via `getMasteredAtLevel()`. Single import, single render. All checks green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated Mastery Progress display on the dashboard to show the count of mastered content items and current reading level.

* **Tests**
  * Added test coverage for the new Mastery Progress feature to ensure accurate data rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->