### PR TITLE
fix: populate ReadingPassage glossary from enriched corpus

### DIFF
--- a/lib/data/__tests__/mapToReading.test.ts
+++ b/lib/data/__tests__/mapToReading.test.ts
@@ -64,6 +64,10 @@ describe('mapToReading', () => {
     expect(result.glossary).toEqual({ gallia: 'Gaul' });
   });
 
+  it('throws on empty input', () => {
+    expect(() => mapToReading([])).toThrow('mapToReading requires at least one sentence');
+  });
+
   it('preserves other ReadingPassage fields correctly', () => {
     mockedGetVocab.mockReturnValue([]);
 

--- a/lib/data/convexAdapter.ts
+++ b/lib/data/convexAdapter.ts
@@ -119,6 +119,9 @@ function buildGlossaryFromCorpus(sentenceIds: string[]): Record<string, string> 
 
 /** @internal exported for testing */
 export function mapToReading(sentences: SentenceDoc[]): ReadingPassage {
+  if (sentences.length === 0) {
+    throw new Error('mapToReading requires at least one sentence');
+  }
   const first = sentences[0];
   const parts = first.sentenceId.split('.');
   const sentenceIds = sentences.map((s) => s.sentenceId);


### PR DESCRIPTION
## Summary

- Fixes empty glossary in production `ReadingPassage` — pre-reading tooltips now show English glosses when users hover Latin words
- `mapToReading()` in `convexAdapter.ts` now builds the glossary from enriched corpus vocabulary via `getVocabForSentences()`, instead of hardcoding `{}`
- Gracefully degrades to empty glossary when no vocabulary data exists for a passage

## Test plan

- [x] Unit tests for `mapToReading()` — glossary population, empty fallback, case normalization, field preservation
- [x] TypeScript compiles clean (`npx tsc --noEmit`)
- [x] ESLint + token lint pass (`bun check`)
- [ ] Manual: navigate to a reading passage in dev, hover Latin words before submitting — tooltips should appear

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reading passages now include automatically populated, case-insensitive glossaries built from the enriched corpus vocabulary.

* **Bug Fixes**
  * Reading generation now validates input and fails fast on empty input to prevent invalid passages.

* **Tests**
  * Added tests covering glossary population, case-insensitive keys, preservation of passage fields when vocabulary is absent, and handling of a missing enriched corpus.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Before / After

**Before:** PR was in CONFLICTING state — branch diverged from master (10 commits behind). 3 unresolved Gemini review threads.

**After:** Rebased onto current master. Conflicts in `lib/data/convexAdapter.ts` resolved semantically — kept master's `buildGlossaryFromCorpus` helper with `isEnrichedCorpusLoaded()` guard, integrated PR's `.toLowerCase()` case normalization, exported `mapToReading` and `SentenceDoc` for testing. Deduplicated `loadEnrichedCorpus()` call. Applied `Object.fromEntries()` from review feedback. Tests updated to mock `isEnrichedCorpusLoaded`. All 5 tests pass, TypeScript clean, Quality Checks green.