### PR TITLE
fix: add sentry capture to global and route error boundaries

### DIFF
--- a/app/(app)/dashboard/error.tsx
+++ b/app/(app)/dashboard/error.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect } from 'react';
+import * as Sentry from '@sentry/nextjs';
 import { Button } from '@/components/UI/Button';
 
 export default function DashboardError({
@@ -11,7 +12,7 @@ export default function DashboardError({
   reset: () => void;
 }) {
   useEffect(() => {
-    console.error('Dashboard error:', error);
+    Sentry.captureException(error);
   }, [error]);
 
   return (

--- a/app/(app)/session/error.tsx
+++ b/app/(app)/session/error.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { useEffect } from 'react';
+import * as Sentry from '@sentry/nextjs';
+import { Button } from '@/components/UI/Button';
+
+export default function SessionError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    Sentry.captureException(error);
+  }, [error]);
+
+  return (
+    <main className="min-h-dvh bg-background text-text-primary flex items-center justify-center">
+      <div className="max-w-md mx-auto px-6 text-center space-y-4">
+        <h1 className="text-2xl font-serif">Session unavailable</h1>
+        <p className="text-text-secondary text-sm">We hit an unexpected issue while loading this session.</p>
+        <Button onClick={reset} labelLatin="Iterum Tempta" labelEnglish="Try Again" />
+      </div>
+    </main>
+  );
+}

--- a/app/(app)/settings/error.tsx
+++ b/app/(app)/settings/error.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { useEffect } from 'react';
+import * as Sentry from '@sentry/nextjs';
+import { Button } from '@/components/UI/Button';
+
+export default function SettingsError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    Sentry.captureException(error);
+  }, [error]);
+
+  return (
+    <main className="min-h-dvh bg-background text-text-primary flex items-center justify-center">
+      <div className="max-w-md mx-auto px-6 text-center space-y-4">
+        <h1 className="text-2xl font-serif">Settings unavailable</h1>
+        <p className="text-text-secondary text-sm">We hit an unexpected issue while loading your settings.</p>
+        <Button onClick={reset} labelLatin="Iterum Tempta" labelEnglish="Try Again" />
+      </div>
+    </main>
+  );
+}

--- a/app/(app)/subscribe/error.tsx
+++ b/app/(app)/subscribe/error.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { useEffect } from 'react';
+import * as Sentry from '@sentry/nextjs';
+import { Button } from '@/components/UI/Button';
+
+export default function SubscribeError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    Sentry.captureException(error);
+  }, [error]);
+
+  return (
+    <main className="min-h-dvh bg-background text-text-primary flex items-center justify-center">
+      <div className="max-w-md mx-auto px-6 text-center space-y-4">
+        <h1 className="text-2xl font-serif">Subscription page unavailable</h1>
+        <p className="text-text-secondary text-sm">We hit an unexpected issue while loading billing options.</p>
+        <Button onClick={reset} labelLatin="Iterum Tempta" labelEnglish="Try Again" />
+      </div>
+    </main>
+  );
+}

--- a/app/(app)/summary/error.tsx
+++ b/app/(app)/summary/error.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { useEffect } from 'react';
+import * as Sentry from '@sentry/nextjs';
+import { Button } from '@/components/UI/Button';
+
+export default function SummaryError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    Sentry.captureException(error);
+  }, [error]);
+
+  return (
+    <main className="min-h-dvh bg-background text-text-primary flex items-center justify-center">
+      <div className="max-w-md mx-auto px-6 text-center space-y-4">
+        <h1 className="text-2xl font-serif">Summary unavailable</h1>
+        <p className="text-text-secondary text-sm">We hit an unexpected issue while loading your session recap.</p>
+        <Button onClick={reset} labelLatin="Iterum Tempta" labelEnglish="Try Again" />
+      </div>
+    </main>
+  );
+}

--- a/app/__tests__/error-boundaries.test.tsx
+++ b/app/__tests__/error-boundaries.test.tsx
@@ -1,0 +1,58 @@
+/** @vitest-environment jsdom */
+
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+const { captureException } = vi.hoisted(() => ({
+  captureException: vi.fn(),
+}));
+
+vi.mock('@sentry/nextjs', () => ({
+  captureException,
+}));
+
+import GlobalError from '@/app/global-error';
+import DashboardError from '@/app/(app)/dashboard/error';
+import SessionError from '@/app/(app)/session/error';
+import SettingsError from '@/app/(app)/settings/error';
+import SubscribeError from '@/app/(app)/subscribe/error';
+import SummaryError from '@/app/(app)/summary/error';
+
+describe('error boundaries', () => {
+  beforeEach(() => {
+    captureException.mockReset();
+  });
+
+  it.each([
+    ['dashboard', DashboardError],
+    ['session', SessionError],
+    ['settings', SettingsError],
+    ['subscribe', SubscribeError],
+    ['summary', SummaryError],
+  ])('%s route captures exceptions on mount', async (_, Component) => {
+    const error = new Error('route exploded');
+    const reset = vi.fn();
+
+    render(<Component error={error} reset={reset} />);
+
+    await waitFor(() => {
+      expect(captureException).toHaveBeenCalledWith(error);
+    });
+  });
+
+  it('global error captures exception and supports reset', async () => {
+    const error = new Error('global exploded');
+    const reset = vi.fn();
+
+    render(<GlobalError error={error} reset={reset} />);
+
+    await waitFor(() => {
+      expect(captureException).toHaveBeenCalledWith(error);
+    });
+
+    expect(screen.getByText('Application Error')).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'Reload' }));
+    expect(reset).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { useEffect } from 'react';
+import * as Sentry from '@sentry/nextjs';
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    Sentry.captureException(error);
+  }, [error]);
+
+  return (
+    <html lang="en">
+      <body>
+        <main className="min-h-dvh bg-background text-text-primary flex items-center justify-center">
+          <div className="max-w-md mx-auto px-6 text-center space-y-4">
+            <h1 className="text-3xl font-display tracking-tight">Application Error</h1>
+            <p className="text-text-secondary">An unexpected error occurred.</p>
+            <button
+              type="button"
+              onClick={reset}
+              className="inline-flex items-center justify-center rounded-pill bg-accent text-accent-foreground px-5 py-2.5 font-medium hover:bg-accent-hover transition-colors"
+            >
+              Reload
+            </button>
+          </div>
+        </main>
+      </body>
+    </html>
+  );
+}

--- a/lib/__tests__/logger.test.ts
+++ b/lib/__tests__/logger.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { captureException } = vi.hoisted(() => ({
+  captureException: vi.fn(),
+}));
+
+vi.mock('@sentry/nextjs', () => ({
+  captureException,
+}));
+
+import { logError } from '@/lib/logger';
+
+describe('logError', () => {
+  beforeEach(() => {
+    captureException.mockReset();
+  });
+
+  it('captures Error instances in sentry with extra fields', () => {
+    const error = new Error('boom');
+
+    logError(error, { context: 'unit-test', route: '/dashboard' });
+
+    expect(captureException).toHaveBeenCalledWith(
+      error,
+      expect.objectContaining({
+        extra: expect.objectContaining({
+          context: 'unit-test',
+          route: '/dashboard',
+        }),
+      }),
+    );
+  });
+});

--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -1,3 +1,5 @@
+import * as Sentry from '@sentry/nextjs';
+
 type LogLevel = 'debug' | 'info' | 'warn' | 'error';
 type LogFields = Record<string, unknown>;
 
@@ -63,5 +65,13 @@ function normalizeError(error: unknown): { message: string; fields: LogFields } 
 
 export function logError(error: unknown, fields: LogFields = {}): void {
   const normalized = normalizeError(error);
-  logger.error(normalized.message, { ...fields, ...normalized.fields });
+  const extra = { ...fields, ...normalized.fields };
+  logger.error(normalized.message, extra);
+
+  if (error instanceof Error) {
+    Sentry.captureException(error, { extra });
+    return;
+  }
+
+  Sentry.captureException(new Error(normalized.message), { extra });
 }


### PR DESCRIPTION
## Summary
Fixes critical observability gap for uncaught route errors by adding Sentry reporting in all app error boundaries and bridging `logError()` into `Sentry.captureException`.

Closes #124.

## Changes
- Added root boundary: `app/global-error.tsx` with `Sentry.captureException(error)`.
- Updated existing dashboard boundary to report to Sentry.
- Added new route boundaries with Sentry capture:
  - `app/(app)/session/error.tsx`
  - `app/(app)/settings/error.tsx`
  - `app/(app)/subscribe/error.tsx`
  - `app/(app)/summary/error.tsx`
- Updated `lib/logger.ts` so `logError()` now forwards errors to Sentry with structured `extra` metadata.
- Added tests:
  - `app/__tests__/error-boundaries.test.tsx`
  - `lib/__tests__/logger.test.ts`

## Acceptance Criteria
- [x] Add `app/global-error.tsx` root boundary with Sentry capture.
- [x] Update `app/(app)/dashboard/error.tsx` to capture exception in Sentry.
- [x] Add `error.tsx` boundaries for session/settings/subscribe/summary routes, each capturing exception in Sentry.
- [x] Ensure `lib/logger.ts` forwards logged errors to Sentry via `captureException`.
- [x] Build succeeds without TypeScript errors.

## Manual QA
1. `bun lint`
Expected: Pass (warnings only in unrelated files).

2. `bun vitest`
Expected: All tests pass, including new boundary/logger tests.

3. `bun run build`
Expected: Successful production build.

4. `bun dev:next` and request touched routes:
   - `curl -i http://localhost:3000/`
   - `curl -i http://localhost:3000/dashboard`
   - `curl -i http://localhost:3000/session/new`
   - `curl -i http://localhost:3000/settings`
   - `curl -i http://localhost:3000/subscribe`
   - `curl -i http://localhost:3000/summary/test`
Expected: app serves correctly; auth-gated routes return gated responses in local unauth context (404 here due middleware/auth behavior), no runtime crashes in dev logs.

## What Changed
```mermaid
graph TD
  A[Unhandled route exception] --> B[Next.js error boundary]
  B --> C[Sentry.captureException(error)]
  C --> D[Sentry event stream]

  E[logError(error, fields)] --> F[Structured console log]
  E --> G[Sentry.captureException(error, extra)]
  G --> D
```

## Before / After
- Before: only dashboard had an error boundary, and it only logged to console; other app routes had no boundary files; `logError()` never sent exceptions to Sentry.
- After: global + all targeted route boundaries capture exceptions to Sentry, and `logError()` also reports exceptions with metadata.

## Test Coverage
- Added `app/__tests__/error-boundaries.test.tsx`:
  - verifies each route boundary calls `captureException` on mount
  - verifies global boundary capture + reset button behavior
- Added `lib/__tests__/logger.test.ts`:
  - verifies `logError()` sends Error instances to Sentry with `extra` context
- Coverage run in pre-push (`vitest --coverage`) includes:
  - `app/global-error.tsx` 100%
  - new route `error.tsx` files 100%
