### PR TITLE
ci: add merge gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,14 +111,17 @@ jobs:
 
   merge-gate:
     name: merge-gate
-    needs: [quality]
+    needs: [quality, convex]
     runs-on: ubuntu-latest
     if: always()
     steps:
-      - run: |
-          if [[ "${{ needs.quality.result }}" == "success" ]]; then
-            echo "merge-gate green"
+      - env:
+          QUALITY_RESULT: ${{ needs.quality.result }}
+          CONVEX_RESULT: ${{ needs.convex.result }}
+        run: |
+          if [[ "$QUALITY_RESULT" == "success" ]] && [[ "$CONVEX_RESULT" == "success" || "$CONVEX_RESULT" == "skipped" ]]; then
+            echo "merge-gate green (quality=$QUALITY_RESULT convex=$CONVEX_RESULT)"
           else
-            echo "merge-gate red (quality=${{ needs.quality.result }})"
+            echo "merge-gate red (quality=$QUALITY_RESULT convex=$CONVEX_RESULT)"
             exit 1
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,3 +108,17 @@ jobs:
 
       - name: Type check Convex functions
         run: bun tsc --noEmit --project convex/tsconfig.json
+
+  merge-gate:
+    name: merge-gate
+    needs: [quality]
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - run: |
+          if [[ "${{ needs.quality.result }}" == "success" ]]; then
+            echo "merge-gate green"
+          else
+            echo "merge-gate red (quality=${{ needs.quality.result }})"
+            exit 1
+          fi


### PR DESCRIPTION
## Why This Matters
- **Problem:** repo CI had no single deterministic status that branch protection could rely on without wiring multiple checks together, and the first draft of `merge-gate` still let Convex-specific failures slip past.
- **Value:** this PR adds one stable merge gate name while preserving the real quality gates underneath it.
- **Why now:** org-wide stewardship is standardizing repos on a single required merge gate.
- **Issue:** org-wide CI hardening / merge-gate rollout.

## Trade-offs / Risks
- **Value gained:** branch protection can key off one deterministic check instead of a fragile set of bot and workflow statuses.
- **Cost / risk incurred:** workflow logic is a little more explicit because conditional Convex runs need special handling.
- **Why this is still the right trade:** the extra condition keeps the gate honest—Convex failures block merges, expected skipped Convex runs do not.
- **Reviewer watch-outs:** ensure `convex=skipped` is only treated as acceptable when the Convex job was legitimately not applicable.

## What Changed
This PR adds a `merge-gate` job to CI and, after review, updates that gate so it evaluates both the always-on `quality` job and the conditional `convex` validation job.

### Base Branch
```mermaid
graph TD
  A[PR opens] --> B[quality job runs]
  A --> C[convex job may run]
  B --> D[branch protection inspects multiple checks]
  C --> D
```

### This PR
```mermaid
graph TD
  A[PR opens] --> B[quality job runs]
  A --> C[convex job may run]
  B --> D[merge-gate]
  C --> D
  D --> E[single required status]
```

### Architecture / State Change
```mermaid
stateDiagram-v2
  [*] --> QualityResult
  QualityResult --> GateGreen: quality=success AND convex in {success, skipped}
  QualityResult --> GateRed: quality!=success
  GateGreen --> [*]
  GateRed --> [*]
  QualityResult --> ConvexFailure: convex in {failure, cancelled, timed_out, action_required}
  ConvexFailure --> GateRed
```

Why this is better:
- Convex validation can no longer fail silently behind a green aggregate gate.
- Non-Convex PRs still get one deterministic status without being punished for a skipped conditional job.

<details>
<summary>Intent Reference</summary>

## Intent Reference
- Org policy is moving repos toward one deterministic merge gate.
- Reviewer intent on this PR was to preserve existing real quality gates rather than hide them behind a weaker aggregate status.

</details>

<details>
<summary>Changes</summary>

## Changes
- add `merge-gate` to `.github/workflows/ci.yml`
- make `merge-gate` depend on both `quality` and `convex`
- allow `convex=skipped` as the expected outcome for non-Convex changes
- surface both upstream results in the gate log line

</details>

<details>
<summary>Acceptance Criteria</summary>

## Acceptance Criteria
- [x] repo has a stable `merge-gate` job name
- [x] gate fails when `quality` fails
- [x] gate fails when applicable Convex validation fails
- [x] gate stays green when Convex is legitimately skipped

</details>

<details>
<summary>Manual QA</summary>

## Manual QA
- reviewed the workflow diff locally after checkout of PR branch
- verified the gate logic covers `quality` and conditional `convex` results
- installed dependencies with `bun install --frozen-lockfile`
- ran `bun check` locally (passed with existing warnings only)
- ran `bun test:ci` locally; it still fails on a pre-existing `components/dashboard/__tests__/FirstSessionGuidance.test.tsx` localStorage harness issue unrelated to this workflow-only change
- authoritative post-fix verification is the GitHub Actions `merge-gate` run on this PR head

</details>

<details>
<summary>Walkthrough</summary>

## Walkthrough
- **Renderer:** Terminal walkthrough
- **Artifact:** steward update comment: https://github.com/misty-step/caesar-in-a-year/pull/140#issuecomment-4033648430
- **Claim:** `merge-gate` now blocks merges on Convex failures while still allowing expected skipped Convex runs
- **Before / After scope:** `.github/workflows/ci.yml` aggregate gate behavior
- **Persistent verification:** GitHub Actions `merge-gate` check on commit `bc5f293`
- **Residual gap:** local pre-push hooks still require app-specific env setup that is intentionally outside this workflow-only PR

</details>

<details>
<summary>Before / After</summary>

## Before / After
- **Before:** `merge-gate` only checked `quality`, so Convex failures could be bypassed once branch protection relied on the aggregate gate.
- **After:** `merge-gate` fails on bad `quality` or bad `convex`, and only treats `convex=skipped` as acceptable.
- Screenshots are not needed because this change is internal to CI behavior.

</details>

<details>
<summary>Test Coverage</summary>

## Test Coverage
- Existing GitHub Actions checks on this PR head
- local `bun check`
- local `bun test:ci` run used as regression smoke, with one unrelated pre-existing failure in `components/dashboard/__tests__/FirstSessionGuidance.test.tsx`

</details>

<details>
<summary>Merge Confidence</summary>

## Merge Confidence
- **Confidence level:** high once refreshed GitHub Actions are green
- **Strongest evidence:** the workflow diff is narrowly scoped and directly addresses the live review finding; existing PR checks were already green before the fix
- **Remaining uncertainty:** local repo baseline still has unrelated test/env friction, so GitHub Actions remains the source of truth for merge readiness
- **What could still go wrong:** if the conditional Convex job fires in an unexpected state not covered by `success|skipped`, the aggregate gate will correctly fail and require follow-up rather than silently passing

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a merge gate to the CI pipeline that validates both quality and secondary checks before allowing merges.
  * Gate now enforces stricter pass/fail logic: the pipeline fails if either check fails, and reports clear success or failure status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->